### PR TITLE
add ReadLine.SetHistory to support multiple histories

### DIFF
--- a/src/ReadLine/ReadLine.cs
+++ b/src/ReadLine/ReadLine.cs
@@ -15,6 +15,7 @@ namespace System
         }
 
         public static void AddHistory(params string[] text) => _history.AddRange(text);
+        public static void SetHistory(List<string> history) => _history = history;
         public static List<string> GetHistory() => _history;
         public static void ClearHistory() => _history = new List<string>();
         public static bool HistoryEnabled { get; set; }

--- a/test/ReadLine.Tests/ReadLineTests.cs
+++ b/test/ReadLine.Tests/ReadLineTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -34,6 +35,15 @@ namespace ReadLine.Tests
             Assert.Equal("ls -a", GetHistory()[0]);
             Assert.Equal("dotnet run", GetHistory()[1]);
             Assert.Equal("git init", GetHistory()[2]);
+        }
+
+        [Fact]
+        public void TestSetHistoryReplacesHistory()
+        {
+            SetHistory(new List<string>{"new", "history"});
+            Assert.Equal(2, GetHistory().Count);
+            Assert.Equal("new", GetHistory()[0]);
+            Assert.Equal("history", GetHistory()[1]);
         }
 
         public void Dispose()


### PR DESCRIPTION
This supports cases where ReadLine.Read can be called for
different prompts and retain a unique history per prompt.