### PR TITLE
Add prompt write override

### DIFF
--- a/src/ReadLine/ReadLine.cs
+++ b/src/ReadLine/ReadLine.cs
@@ -19,10 +19,11 @@ namespace System
         public static void ClearHistory() => _history = new List<string>();
         public static bool HistoryEnabled { get; set; }
         public static IAutoCompleteHandler AutoCompletionHandler { private get; set; }
-
+        public static Action<string> WritePrompt { private get; set; } = (prompt) => Console.Write(prompt);
+        
         public static string Read(string prompt = "", string @default = "")
         {
-            Console.Write(prompt);
+            WritePrompt(prompt);
             KeyHandler keyHandler = new KeyHandler(new Console2(), _history, AutoCompletionHandler);
             string text = GetText(keyHandler);
 
@@ -41,7 +42,7 @@ namespace System
 
         public static string ReadPassword(string prompt = "")
         {
-            Console.Write(prompt);
+            WritePrompt(prompt);
             KeyHandler keyHandler = new KeyHandler(new Console2() { PasswordMode = true }, null, null);
             return GetText(keyHandler);
         }

--- a/src/ReadLine/ReadLine.csproj
+++ b/src/ReadLine/ReadLine.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyTitle>ReadLine</AssemblyTitle>
     <AssemblyDescription>A GNU-Readline like library for .NET/.NET Core</AssemblyDescription>
-    <AssemblyVersion>2.0.0</AssemblyVersion>
+    <AssemblyVersion>2.0.1</AssemblyVersion>
     <Authors>Toni Solarin-Sodara</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <DebugType>portable</DebugType>

--- a/src/ReadLine/ReadLine.csproj
+++ b/src/ReadLine/ReadLine.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyTitle>ReadLine</AssemblyTitle>
     <AssemblyDescription>A GNU-Readline like library for .NET/.NET Core</AssemblyDescription>
-    <AssemblyVersion>2.0.1</AssemblyVersion>
+    <AssemblyVersion>2.0.0</AssemblyVersion>
     <Authors>Toni Solarin-Sodara</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <DebugType>portable</DebugType>


### PR DESCRIPTION
This allows a user to override the way the Prompt is written so that changes to formatting can be introduced.

i.e.
```c#
System.ReadLine.WritePrompt = (prompt) => {
    Console.ForegroundColor = ConsoleColor.Yellow;
    Console.Write(prompt);
    Console.ResetColor();
};
```